### PR TITLE
Integrate WatermelonDB services on frontend

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -19,6 +19,10 @@
 
 ## 🚧 In Progress / Next Up
 - [ ] **Convert Frontend to React + PixiJS**: Migrate from vanilla JS to React components with PixiJS integration
+- [ ]    - Setup React with Vite and install `react` and `react-dom`
+- [ ]    - Create `<PixiCanvas>` component wrapping PixiJS Application
+- [ ]    - Refactor game UI overlays into React components
+- [ ]    - Replace menu and popovers with React equivalents
 - [ ] **Frontend Game Creation**: Implement "New Game" button using WatermelonDB GameService locally
 - [ ] **WatermelonDB Sync Setup**: Configure sync between frontend WatermelonDB and backend D1 for cloud saves
 - [ ] Procedural Galaxy Generation (moved to frontend)

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,16 +1,16 @@
 import { Database } from '@nozbe/watermelondb';
-import SQLiteAdapter from '@nozbe/watermelondb/adapters/sqlite';
+import LokiJSAdapter from '@nozbe/watermelondb/adapters/lokijs';
 
 import Galaxy from './models/galaxy';
 import Game from './models/game';
 import schema from './schema';
 import { GameService } from './services/game-service';
 
-const adapter = new SQLiteAdapter({
-	schema,
-	// migrations: [], // Add when needed
-	dbName: 'stargate_evolution',
-	jsi: true, // Platform-specific, set to false for web
+const adapter = new LokiJSAdapter({
+       schema,
+       dbName: 'stargate_evolution',
+       useWebWorker: false,
+       useIncrementalIndexedDB: true,
 });
 
 export const database = new Database({

--- a/packages/db/src/services/game-service.ts
+++ b/packages/db/src/services/game-service.ts
@@ -1,4 +1,4 @@
-import { Database } from '@nozbe/watermelondb';
+import { Database, Q } from '@nozbe/watermelondb';
 import { ulid } from 'ulid';
 
 import Galaxy from '../models/galaxy';
@@ -10,7 +10,7 @@ export class GameService {
 	/**
 	 * Create a new game with all initial data
 	 */
-	async createNewGame(userId: string): Promise<string> {
+async createNewGame(userId: string): Promise<string> {
 		return await this.database.write(async () => {
 			const gameId = ulid();
 			const now = Date.now();
@@ -316,7 +316,45 @@ export class GameService {
 				(record._raw as any).created_at = now;
 			});
 
-			return gameId;
-		});
-	}
+return gameId;
+});
 }
+
+/**
+ * List all games for a user
+ */
+async listGames(userId: string) {
+return await this.database
+.get<Game>('games')
+.query(Q.where('user_id', userId))
+.fetch();
+}
+
+/**
+ * Load game data with all related tables
+ */
+async getGameData(gameId: string) {
+const tables = [
+'galaxies',
+'star_systems',
+'stars',
+'planets',
+'stargates',
+'chevrons',
+'technology',
+'races',
+'ships',
+'destiny_status',
+'people',
+];
+const result: Record<string, any[]> = {};
+for (const table of tables) {
+result[table] = await this.database
+.get<any>(table)
+.query(Q.where('game_id', gameId))
+.fetch();
+}
+return result;
+}
+}
+

--- a/packages/frontend/src/game-menu.ts
+++ b/packages/frontend/src/game-menu.ts
@@ -5,7 +5,7 @@ import { GameSummaryListSchema } from '@stargate/common/types/game';
 
 import { listGames, ApiError } from './api-client';
 import { getSession } from './auth/session';
-// TODO: Import GameService from WatermelonDB once frontend conversion to React is complete
+import { gameService } from '@stargate/db';
 
 export type GameSummary = typeof GameSummaryListSchema._type[number];
 
@@ -87,16 +87,13 @@ export class GameMenu {
 		if (loadBtn) loadBtn.addEventListener('click', () => this.showLoadDialog());
 	}
 
-	static async createGame() {
-		// TODO: Use WatermelonDB GameService to create games locally once React conversion is complete
-		alert('Game creation will be available after converting frontend to React + WatermelonDB');
-		// const session = getSession();
-		// if (!session || !session.user) return;
-		// const gameService = new GameService(database);
-		// const gameId = await gameService.createNewGame(session.user.id);
-		// this.hide();
-		// this.onStartGame(gameId);
-	}
+static async createGame() {
+const session = getSession();
+if (!session || !session.user) return;
+const gameId = await gameService.createNewGame(session.user.id);
+this.hide();
+this.onStartGame(gameId);
+}
 
 	static showLoadDialog() {
 		let html = '<h2>Load Game</h2><ul class=\'game-list\'>';

--- a/packages/frontend/src/main.ts
+++ b/packages/frontend/src/main.ts
@@ -8,6 +8,7 @@ import { Game } from './game';
 import { GameMenu } from './game-menu';
 import { MapPopover } from './map-popover';
 import { Toast } from './toast';
+import { gameService } from '@stargate/db';
 
 const app = new PIXI.Application();
 await app.init({
@@ -65,11 +66,13 @@ GameMenu.show(async (gameId: string) => {
 		return;
 	}
 	try {
-		const gameData = await getGame({ userId: session.user.id, gameId }, session.token);
-		console.log('Loaded game data:', gameData);
-		// TODO: Load destiny status from WatermelonDB once React conversion is complete
-		// const destinyStatus = await gameService.getDestinyStatus(gameId);
-		// DestinyStatusBar.show(destinyStatus);
+const gameData = await getGame({ userId: session.user.id, gameId }, session.token);
+console.log('Loaded game data:', gameData);
+const local = await gameService.getGameData(gameId);
+const destinyStatus = local.destiny_status?.[0];
+if (destinyStatus) {
+DestinyStatusBar.show(destinyStatus as any);
+}
 
 		// Placeholder: Draw a simple rectangle representing the Destiny ship
 		const ship = new PIXI.Graphics();

--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -1,7 +1,8 @@
 {
 	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"jsx": "preserve"
-	},
+"compilerOptions": {
+"jsx": "preserve",
+"experimentalDecorators": true
+},
 	"include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,9 @@
       ],
       "@stargate/db/*": [
         "packages/db/*"
+      ],
+      "@stargate/db": [
+        "packages/db/src/index"
       ]
     }
   }


### PR DESCRIPTION
## Summary
- switch WatermelonDB adapter to LokiJS for the browser
- expose helper methods in `GameService`
- use `GameService` to create games and read status on startup
- enable decorators for frontend TypeScript
- update tsconfig paths for `@stargate/db`
- expand roadmap tasks for React + PixiJS migration

## Testing
- `pnpm -r run typecheck`
- `pnpm -r run lint` *(fails: Cannot find package '@eslint/eslintrc')*
