### PR TITLE
Fix room event schema mismatch

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -17,6 +17,8 @@
 - [x] Auto-Generated D1 Migration System: Complete migration from Sequelize to CloudFlare D1 with auto-generated schema from TypeScript models, full test coverage, and working create/get game endpoints
 - [x] **Frontend-First Database Architecture**: Created `packages/db` with WatermelonDB schema, models, and GameService for offline-first game creation
 - [x] Frontend deployment configured with Wrangler for Cloudflare Pages
+- [x] Fixed room creation null handling bug in `use-game-service`
+- [x] Refactored room creation with `roomTemplateToEvent` utility
 
 ## 🚧 In Progress / Next Up
 - [ ] **Convert Frontend to React + PixiJS**: Migrate from vanilla JS to React components with PixiJS integration

--- a/docs/playtesting.md
+++ b/docs/playtesting.md
@@ -4,4 +4,6 @@ Document all major playtest results and bugs here.
 
 - [ ] Initial playtest: PixiJS canvas renders
 - [ ] Backend API responds to /hello
-- [ ] ... 
+- [x] Room creation bug fixed (null values causing type errors)
+- [x] Room mapping uses typed converter to avoid future null issues
+- [ ] ...

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,4 +1,6 @@
 export * from './sleep';
 export * from './time-display';
 export * from './trim-nulls';
+export * from './null-to-undefined';
 export * from './zod-templates';
+export * from './room-utils';

--- a/packages/common/src/null-to-undefined.ts
+++ b/packages/common/src/null-to-undefined.ts
@@ -1,0 +1,22 @@
+export type NullToUndefined<T> = T extends null
+        ? undefined
+        : T extends (infer U)[]
+                ? NullToUndefined<U>[]
+                : T extends Record<string, unknown>
+                        ? { [K in keyof T]: NullToUndefined<T[K]> }
+                        : T;
+
+export function nullToUndefined<T>(obj: T): NullToUndefined<T> {
+	if (Array.isArray(obj)) {
+		return obj.map((v) => nullToUndefined(v)) as unknown as NullToUndefined<T>;
+	}
+	if (obj && typeof obj === 'object') {
+		const result: Record<string, unknown> = {};
+		for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+			if (value === null) result[key] = undefined;
+			else result[key] = nullToUndefined(value);
+		}
+		return result as NullToUndefined<T>;
+	}
+	return obj as NullToUndefined<T>;
+}

--- a/packages/common/src/room-utils.ts
+++ b/packages/common/src/room-utils.ts
@@ -1,0 +1,9 @@
+import type { RoomTemplate } from './models/room-template';
+import { nullToUndefined, type NullToUndefined } from './null-to-undefined';
+
+export type RoomEventData = NullToUndefined<Omit<RoomTemplate, 'id' | 'created_at' | 'updated_at'>>;
+
+export function roomTemplateToEvent(room: RoomTemplate): RoomEventData {
+	const { id: _id, created_at: _created_at, updated_at: _updated_at, ...rest } = room;
+	return nullToUndefined(rest);
+}

--- a/packages/frontend/src/services/use-game-service.ts
+++ b/packages/frontend/src/services/use-game-service.ts
@@ -1,5 +1,5 @@
 import { useStore } from '@livestore/react';
-import { RoomTechnology } from '@stargate/common/zod-templates';
+import { RoomTechnology, roomTemplateToEvent, type RoomEventData } from '@stargate/common';
 
 import {
 	gameById$,
@@ -108,17 +108,16 @@ export const useGameService = () => {
 
 		// Default Rooms
 		for (const room of roomTemplates) {
+			const base: RoomEventData = roomTemplateToEvent(room);
 			store.commit(
 				events.roomCreated({
-					...room,
-					// Template ID
+					...base,
 					template_id: room.id,
-					// ID is unique per game
 					id: crypto.randomUUID(),
 					game_id: game_id,
 				}),
 			);
-		};
+		}
 
 		// Add initial inventory
 		for (const item of startingInventory) {
@@ -294,7 +293,7 @@ export const useGameService = () => {
 		store.commit(
 			events.personUpdated({
 				id: personId,
-				assigned_to: roomId,
+				assigned_to: roomId ?? undefined,
 				updated_at: new Date(),
 			}),
 		);


### PR DESCRIPTION
## Summary
- avoid spreading template data with nulls in room creation
- pass undefined for optional fields when assigning crew
- note bug fix in TASKS
- update playtesting log
