### PR TITLE
Add integration tests for frontend-backend sync

### DIFF
--- a/packages/integration/package.json
+++ b/packages/integration/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "integration",
+  "version": "0.1.0",
+  "private": true,
+"scripts": {
+"test": "pnpm exec vitest run"
+},
+  "dependencies": {
+    "@stargate/common": "workspace:*"
+  },
+  "devDependencies": {
+    "@cloudflare/vitest-pool-workers": "^0.8.34",
+    "@livestore/adapter-node": "^0.3.0",
+    "@livestore/livestore": "^0.3.0",
+    "vitest": "^3.1.4",
+    "vite-tsconfig-paths": "^5.1.4"
+  }
+}

--- a/packages/integration/test/apply-migrations.ts
+++ b/packages/integration/test/apply-migrations.ts
@@ -1,0 +1,3 @@
+import { applyD1Migrations, env } from 'cloudflare:test';
+
+await applyD1Migrations((env as any).DB, (env as any).TEST_MIGRATIONS);

--- a/packages/integration/test/create-new-game.spec.ts
+++ b/packages/integration/test/create-new-game.spec.ts
@@ -1,0 +1,50 @@
+import { makeAdapter } from '@livestore/adapter-node';
+import { createStorePromise } from '@livestore/livestore';
+import { SELF, env } from 'cloudflare:test';
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+
+import { schema, tables } from '../../frontend/src/livestore/schema';
+
+let store: any;
+
+vi.mock('@livestore/react', () => ({
+	useStore: () => ({ store }),
+}));
+
+beforeAll(async () => {
+	store = await createStorePromise({
+		schema,
+		adapter: makeAdapter({ storage: { type: 'in-memory' } }),
+		storeId: 'integration',
+		batchUpdates: (run: () => void) => run(),
+		debug: { instanceId: 'test' },
+	});
+	global.fetch = (input: any, init?: any) => {
+		const req = input instanceof Request ? input : new Request(input, init);
+		return SELF.fetch(req);
+	};
+});
+
+describe('createNewGame integration', () => {
+	it('saves templates to frontend db', async () => {
+		const [roomsT, peopleT, racesT, galaxiesT, systemsT, invT] = await Promise.all([
+			SELF.fetch('/api/templates/rooms').then((res: Response) => res.json()),
+			SELF.fetch('/api/templates/people').then((res: Response) => res.json()),
+			SELF.fetch('/api/templates/races').then((res: Response) => res.json()),
+			SELF.fetch('/api/templates/galaxies').then((res: Response) => res.json()),
+			SELF.fetch('/api/templates/star-systems').then((res: Response) => res.json()),
+			SELF.fetch('/api/templates/starting-inventory').then((res: Response) => res.json()),
+		]);
+
+		const { useGameService } = await import('../../frontend/src/services/use-game-service');
+		const service = useGameService();
+		const gameId = await service.createNewGame('integration test');
+
+		expect(store.query(tables.rooms.where({ game_id: gameId })).length).toBe(roomsT.length);
+		expect(store.query(tables.people.where({ game_id: gameId })).length).toBe(peopleT.length);
+		expect(store.query(tables.races.where({ game_id: gameId })).length).toBe(racesT.length);
+		expect(store.query(tables.galaxies.where({ game_id: gameId })).length).toBe(galaxiesT.length);
+		expect(store.query(tables.starSystems.where({ game_id: gameId })).length).toBe(systemsT.length);
+		expect(store.query(tables.inventory.where({ game_id: gameId })).length).toBe(invT.length);
+	});
+});

--- a/packages/integration/tsconfig.json
+++ b/packages/integration/tsconfig.json
@@ -1,0 +1,12 @@
+{
+"extends": "../../tsconfig.json",
+"include": ["test/**/*.ts", "vitest.config.ts"],
+"compilerOptions": {
+"moduleResolution": "bundler",
+"types": [
+"@cloudflare/vitest-pool-workers",
+"vite/client",
+"node"
+]
+}
+}

--- a/packages/integration/vitest.config.ts
+++ b/packages/integration/vitest.config.ts
@@ -1,0 +1,27 @@
+import path from 'node:path';
+import { defineWorkersConfig, readD1Migrations } from '@cloudflare/vitest-pool-workers/config';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+export default defineWorkersConfig(async () => {
+const migrationsPath = path.join(__dirname, '../backend/migrations');
+const migrations = await readD1Migrations(migrationsPath);
+
+return {
+plugins: [tsconfigPaths()],
+test: {
+include: ['test/**/*.spec.ts'],
+setupFiles: ['./test/apply-migrations.ts'],
+poolOptions: {
+workers: {
+miniflare: {
+bindings: { TEST_MIGRATIONS: migrations },
+},
+wrangler: {
+configPath: '../backend/wrangler.toml',
+environment: 'test',
+},
+},
+},
+},
+};
+});


### PR DESCRIPTION
## Summary
- add integration test package that initializes the backend worker and LiveStore
- run migrations and create a memory-backed store
- verify `createNewGame` stores template data via HTTP

## Testing
- `pnpm run check`
- `pnpm -r test` *(fails: vitest not installed in integration package)*


------
https://chatgpt.com/codex/tasks/task_b_683aeba0b70c832bba4fa4f39ab3f327