### PR TITLE
Add floor dropdown to admin

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -20,6 +20,7 @@
 - [x] Frontend deployment configured with Wrangler for Cloudflare Pages
 - [x] Fixed room creation null handling bug in `use-game-service`
 - [x] Refactored room creation with `roomTemplateToEvent` utility
+- [x] Admin portal supports multiple floors with dropdown and elevator room type
 
 ## 🚧 In Progress / Next Up
 - [ ] **Convert Frontend to React + PixiJS**: Migrate from vanilla JS to React components with PixiJS integration

--- a/docs/playtesting.md
+++ b/docs/playtesting.md
@@ -6,4 +6,5 @@ Document all major playtest results and bugs here.
 - [ ] Backend API responds to /hello
 - [x] Room creation bug fixed (null values causing type errors)
 - [x] Room mapping uses typed converter to avoid future null issues
+- [ ] Verified admin floor dropdown and elevator type options
 - [ ] ...

--- a/packages/frontend/src/pages/admin-page.tsx
+++ b/packages/frontend/src/pages/admin-page.tsx
@@ -56,6 +56,7 @@ export const AdminPage: React.FC = () => {
 	const [userSearch, setUserSearch] = useState('');
 	const [roomSearch, setRoomSearch] = useState('');
 	const [techSearch, setTechSearch] = useState('');
+	const [selectedFloor, setSelectedFloor] = useState(0);
 
 	// Modal states
 	const [showUserModal, setShowUserModal] = useState(false);
@@ -105,11 +106,23 @@ export const AdminPage: React.FC = () => {
 		return userFuse.search(userSearch).map(result => result.item);
 	}, [users, userSearch, userFuse]);
 
+	const floors = useMemo(() => {
+		const maxFloor = rooms.reduce((max, r) => Math.max(max, r.floor), 0);
+		return Array.from({ length: maxFloor + 2 }, (_, i) => i);
+	}, [rooms]);
+
+	const roomTypes = useMemo(() => {
+		const types = Array.from(new Set(rooms.map(r => r.type)));
+		if (!types.includes('elevator')) types.push('elevator');
+		return types;
+	}, [rooms]);
+
 	const filteredRooms = useMemo(() => {
-		if (!roomSearch.trim()) return rooms;
-		if (!roomFuse) return rooms;
-		return roomFuse.search(roomSearch).map(result => result.item);
-	}, [rooms, roomSearch, roomFuse]);
+		const result = rooms.filter(r => r.floor === selectedFloor);
+		if (!roomSearch.trim()) return result;
+		if (!roomFuse) return result;
+		return roomFuse.search(roomSearch).map(result => result.item).filter(r => r.floor === selectedFloor);
+	}, [rooms, roomSearch, roomFuse, selectedFloor]);
 
 	const filteredTechnologies = useMemo(() => {
 		if (!techSearch.trim()) return technologies;
@@ -201,7 +214,7 @@ export const AdminPage: React.FC = () => {
 			description: '',
 			width: 1,
 			height: 1,
-			floor: 0,
+			floor: selectedFloor,
 			found: false,
 			locked: false,
 			explored: false,
@@ -489,9 +502,21 @@ export const AdminPage: React.FC = () => {
 							<Card bg="dark" text="light">
 								<Card.Header className="d-flex justify-content-between align-items-center">
 									<h4>Room Templates</h4>
-									<Button variant="primary" onClick={handleCreateRoom}>
-										<FaPlus /> Add Room
-									</Button>
+									<div className="d-flex align-items-center">
+										<Form.Select
+											className="me-2"
+											style={{ width: '120px' }}
+											value={selectedFloor}
+											onChange={(e) => setSelectedFloor(parseInt(e.target.value))}
+										>
+											{floors.map((f) => (
+												<option key={f} value={f}>Floor {f}</option>
+											))}
+										</Form.Select>
+										<Button variant="primary" onClick={handleCreateRoom}>
+											<FaPlus /> Add Room
+										</Button>
+									</div>
 								</Card.Header>
 								<Card.Body>
 									<InputGroup className="mb-3">
@@ -712,11 +737,14 @@ export const AdminPage: React.FC = () => {
 										<div className="col-md-6">
 											<Form.Group className="mb-3">
 												<Form.Label>Type</Form.Label>
-												<Form.Control
-													type="text"
-													value={roomForm.type || ''}
+												<Form.Select
+													value={roomForm.type || 'basic'}
 													onChange={(e) => setRoomForm({ ...roomForm, type: e.target.value })}
-												/>
+												>
+													{roomTypes.map(type => (
+														<option key={type} value={type}>{type}</option>
+													))}
+												</Form.Select>
 											</Form.Group>
 										</div>
 									</div>
@@ -771,12 +799,14 @@ export const AdminPage: React.FC = () => {
 										<div className="col-md-4">
 											<Form.Group className="mb-3">
 												<Form.Label>Floor</Form.Label>
-												<Form.Control
-													type="number"
-													min="0"
-													value={roomForm.floor || 0}
+												<Form.Select
+													value={roomForm.floor ?? selectedFloor}
 													onChange={(e) => setRoomForm({ ...roomForm, floor: parseInt(e.target.value) })}
-												/>
+												>
+													{floors.map(f => (
+														<option key={f} value={f}>Floor {f}</option>
+													))}
+												</Form.Select>
 											</Form.Group>
 										</div>
 									</div>


### PR DESCRIPTION
## Summary
- allow selecting a floor in admin panel
- support elevator room type and render type dropdown
- update tasks and playtesting docs

## Testing
- `pnpm run check`
- `pnpm -r test` *(fails: engineering_west connections)*

------
https://chatgpt.com/codex/tasks/task_b_684e3708d740832ba3270c518a20d600