### PR TITLE
Enable iOS Safari fullscreen PWA

### DIFF
--- a/packages/frontend/index.html
+++ b/packages/frontend/index.html
@@ -2,8 +2,10 @@
 <html lang="en">
 <head>
 	<meta charset='UTF-8' />
-	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-	<title>Stargate Evolution</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+        <title>Stargate Evolution</title>
 	<script src="https://accounts.google.com/gsi/client" async defer></script>
 	<style>
 		html, body {

--- a/packages/frontend/public/assets/site.webmanifest
+++ b/packages/frontend/public/assets/site.webmanifest
@@ -15,7 +15,7 @@
 	],
 	"theme_color": "#0a0f2c",
 	"background_color": "#000000",
-	"display": "standalone",
+       "display": "fullscreen",
 	"start_url": "/",
 	"scope": "/"
 }


### PR DESCRIPTION
## Summary
- allow iOS Safari to open the app fullscreen
- update web manifest to request fullscreen

## Testing
- `pnpm run check`
- `pnpm -r test`


------
https://chatgpt.com/codex/tasks/task_b_686aa4c83710832b97d0edd307244bd3